### PR TITLE
feat: /mode 支持显示与切换自定义 preset

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@larksuiteoapi/node-sdk": "^1.72.0",
+        "@larksuiteoapi/node-sdk": "^1.73.0",
         "axios": "^1.19.0",
         "fflate": "^0.8.3",
         "qrcode": "^1.5.4",
@@ -571,65 +571,6 @@
         "@standard-schema/spec": "^1.1.0"
       }
     },
-    "../pi-feishu-link/node_modules/@larksuiteoapi/node-sdk": {
-      "version": "1.72.0",
-      "license": "MIT",
-      "dependencies": {
-        "axios": "^1.16.0",
-        "lodash.identity": "^3.0.0",
-        "lodash.merge": "^4.6.2",
-        "lodash.pickby": "^4.6.0",
-        "protobufjs": "^7.2.6",
-        "qs": "^6.14.2",
-        "ws": "^8.19.0"
-      },
-      "devDependencies": {
-        "@koa/router": "^12.0.0",
-        "@rollup/plugin-alias": "^3.1.9",
-        "@rollup/plugin-typescript": "^8.3.2",
-        "@types/jest": "^28.1.3",
-        "@types/lodash.merge": "^4.6.7",
-        "@types/lodash.pick": "^4.4.7",
-        "@types/qs": "^6.9.16",
-        "@types/ws": "^8.5.10",
-        "@typescript-eslint/parser": "^5.27.1",
-        "body-parser": "^1.20.1",
-        "eslint": "^8.17.0",
-        "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-prettier": "^8.5.0",
-        "eslint-plugin-import": "^2.26.0",
-        "express": "^4.18.2",
-        "jest": "^28.1.1",
-        "koa": "^2.13.4",
-        "koa-body": "^5.0.0",
-        "prettier": "2.6.2",
-        "rollup": "^2.75.5",
-        "rollup-plugin-dts": "^4.2.2",
-        "rollup-plugin-license": "^2.8.1",
-        "ts-jest": "^28.0.5",
-        "ts-node": "^10.8.1",
-        "tsconfig-paths": "^4.0.0",
-        "tslib": "^2.4.0",
-        "typescript": "^4.7.3"
-      }
-    },
-    "../pi-feishu-link/node_modules/@types/qrcode-terminal": {
-      "version": "0.12.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "../pi-feishu-link/node_modules/qrcode-terminal": {
-      "version": "0.12.0",
-      "bin": {
-        "qrcode-terminal": "bin/qrcode-terminal.js"
-      },
-      "devDependencies": {
-        "expect.js": "*",
-        "jshint": "*",
-        "mocha": "*",
-        "sinon": "*"
-      }
-    },
     "node_modules/@deepseek-ai/cordis": {
       "version": "4.0.1",
       "resolved": "https://registry.npmmirror.com/@deepseek-ai/cordis/-/cordis-4.0.1.tgz",
@@ -927,8 +868,19 @@
       }
     },
     "node_modules/@larksuiteoapi/node-sdk": {
-      "resolved": "../pi-feishu-link/node_modules/@larksuiteoapi/node-sdk",
-      "link": true
+      "version": "1.73.0",
+      "resolved": "https://registry.npmmirror.com/@larksuiteoapi/node-sdk/-/node-sdk-1.73.0.tgz",
+      "integrity": "sha512-gs4EiupJ6RdYAEJGtuYrCVsB7wSMBwtUDK+ilpmOHD6RTvbtciW6AWciQO9coOQVuBZfh7hvAi25dPfCsny/nA==",
+      "license": "MIT",
+      "dependencies": {
+        "axios": "^1.16.0",
+        "lodash.identity": "^3.0.0",
+        "lodash.merge": "^4.6.2",
+        "lodash.pickby": "^4.6.0",
+        "protobufjs": "^7.2.6",
+        "qs": "^6.14.2",
+        "ws": "^8.19.0"
+      }
     },
     "node_modules/@oxc-project/types": {
       "version": "0.144.0",
@@ -939,6 +891,63 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@quansync/fs": {
       "version": "1.0.0",
@@ -1046,9 +1055,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1066,9 +1072,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1086,9 +1089,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1106,9 +1106,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,9 +1123,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1146,9 +1140,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1227,7 +1218,6 @@
       "version": "24.13.3",
       "resolved": "https://registry.npmmirror.com/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -1244,8 +1234,11 @@
       }
     },
     "node_modules/@types/qrcode-terminal": {
-      "resolved": "../pi-feishu-link/node_modules/@types/qrcode-terminal",
-      "link": true
+      "version": "0.12.2",
+      "resolved": "https://registry.npmmirror.com/@types/qrcode-terminal/-/qrcode-terminal-0.12.2.tgz",
+      "integrity": "sha512-v+RcIEJ+Uhd6ygSQ0u5YYY7ZM+la7GgPbs0V/7l/kFs2uO4S8BcIUEMoP7za4DNIqNnUD5npf0A/7kBhrCKG5Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@yuku-codegen/binding-android-arm64": {
       "version": "0.8.7",
@@ -1311,9 +1304,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1328,9 +1318,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1345,9 +1332,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1362,9 +1346,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1379,9 +1360,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1396,9 +1374,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1497,9 +1472,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1514,9 +1486,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1531,9 +1500,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1548,9 +1514,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1565,9 +1528,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1582,9 +1542,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1711,6 +1668,22 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase": {
@@ -2156,6 +2129,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/lodash.identity": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/lodash.identity/-/lodash.identity-3.0.0.tgz",
+      "integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmmirror.com/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.pickby": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmmirror.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
+      "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmmirror.com/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -2191,6 +2188,18 @@
       "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/obug": {
       "version": "2.1.4",
@@ -2273,6 +2282,29 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmmirror.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -2300,8 +2332,28 @@
       }
     },
     "node_modules/qrcode-terminal": {
-      "resolved": "../pi-feishu-link/node_modules/qrcode-terminal",
-      "link": true
+      "version": "0.12.0",
+      "resolved": "https://registry.npmmirror.com/qrcode-terminal/-/qrcode-terminal-0.12.0.tgz",
+      "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ==",
+      "bin": {
+        "qrcode-terminal": "bin/qrcode-terminal.js"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/quansync": {
       "version": "1.0.0",
@@ -2425,6 +2477,78 @@
       "resolved": "https://registry.npmmirror.com/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -2594,7 +2718,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmmirror.com/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/verkit": {
@@ -2628,6 +2751,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmmirror.com/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "@larksuiteoapi/node-sdk": "^1.72.0",
+    "@larksuiteoapi/node-sdk": "^1.73.0",
     "axios": "^1.19.0",
     "fflate": "^0.8.3",
     "qrcode": "^1.5.4",

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -71,7 +71,13 @@ export interface FeishuConfig {
 	allowlist: string[];
 	/** Bridge agent workspace root (cwd for created sessions). Empty = process.cwd(). */
 	workspaceRoot: string;
-	/** Agent preset for bridge sessions (standard | code | minimal | cordis). */
+	/**
+	 * Agent preset for bridge sessions. Any preset id the deployment supplies —
+	 * the shipped `standard | code | minimal | cordis`, OR a locally authored
+	 * (user) preset id created in the DSH GUI — is valid. `/mode` renders the
+	 * live roster (shipped + custom); `/lark-config agentPreset=<id>` accepts
+	 * any id verbatim.
+	 */
 	agentPreset: string;
 	/** Default DSH permission preset (read-only | workspace-write | danger-full-access). */
 	permissionMode: string;

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -86,6 +86,25 @@ export interface DedupeRecord {
   at: number;
 }
 
+/**
+ * One agent preset a bridge session can run on, as surfaced by DSH's
+ * agentPresets service. Harness-agnostic mirror of the roster row: the DSH
+ * adapter maps its `AgentPreset` onto this shape, and the memory backend
+ * simulates it, so the presentation layer never touches DSH types.
+ */
+export interface AgentPresetOption {
+  /** Stable id (the preset directory name); also the /mode argument. */
+  id: string;
+  /** Display label; falls back to `id` when the preset publishes none. */
+  label: string;
+  /** One sentence on what the preset is for. */
+  desc?: string;
+  /** 'system' ships with DSH; 'user' was authored locally. */
+  trust?: "system" | "user";
+  /** Why this preset cannot compose a session (absent = usable). */
+  broken?: string;
+}
+
 /** Connection state machine. */
 export type ConnState = "idle" | "connecting" | "connected" | "degraded" | "reconnecting" | "quarantined" | "stopped";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -923,21 +923,29 @@ export function apply(ctx: Context, rawConfig: unknown): void {
 			}
 			case "mode": {
 				// /mode — picker card (single-select buttons) or switch by name.
+				// The roster is LIVE: shipped presets + user-authored (custom)
+				// ones, read from DSH's agentPresets service so a preset created
+				// in the GUI is selectable here too. AGENT_PRESETS is only the
+				// fallback when the service is unreachable.
+				const live = backend ? await backend.listPresets() : [];
+				const roster = live.length > 0 ? live : [...AGENT_PRESETS];
 				const arg = _rawInput.trim().toLowerCase();
 				if (!arg) {
 					await sender.sendCard(
 						msg.chatId,
 						withButtons(
-							modeCard(getCfg().agentPreset),
-							AGENT_PRESETS.map((p) => button(p.label, { op: `mode:${p.id}` })),
+							modeCard(getCfg().agentPreset, roster),
+							roster
+								.filter((p) => !p.broken)
+								.map((p) => button(p.label, { op: `mode:${p.id}` })),
 						),
 					);
 					return true;
 				}
-				if (!AGENT_PRESETS.some((p) => p.id === arg)) {
+				if (!roster.some((p) => p.id === arg)) {
 					await sender.replyTo(
 						msg,
-						`未知模式 ${arg}（可用: ${AGENT_PRESETS.map((p) => p.id).join(", ")}）`,
+						`未知模式 ${arg}（可用: ${roster.map((p) => p.id).join(", ")}）`,
 					);
 					return true;
 				}
@@ -951,9 +959,12 @@ export function apply(ctx: Context, rawConfig: unknown): void {
 				// store AND the next message would reuse the same sessionId (stale
 				// content / id collision).
 				await conversations?.rotate(bridge.conversationKeyFor(msg));
+				const picked = roster.find((p) => p.id === arg);
 				await sender.replyTo(
 					msg,
-					`模式已切换为 ${arg}（当前会话已重置，下条消息生效；其他会话不受影响）`,
+					`模式已切换为 ${picked?.label ?? arg}${
+						picked?.trust === "user" ? "（自定义）" : ""
+					}（当前会话已重置，下条消息生效；其他会话不受影响）`,
 				);
 				return true;
 			}

--- a/src/presentation/cards.ts
+++ b/src/presentation/cards.ts
@@ -5,6 +5,8 @@
 // width:"fill" 防截断），交互回传用 behaviors:[{type:"callback",value}]。
 // emoji 精简为稳定集合（部分 emoji 在部分客户端字体渲染乱码）。
 
+import type { AgentPresetOption } from "../common/types.ts";
+
 export type CardVariant = "status" | "help" | "setup" | "welcome" | "error";
 
 /** Card button value (op routing). */
@@ -69,31 +71,38 @@ export function markdownCard(
 	};
 }
 
-/** Agent preset options (DSH agent-presets). */
-export const AGENT_PRESETS: ReadonlyArray<{
-	id: string;
-	label: string;
-	desc: string;
-}> = [
+/**
+ * Agent preset options (DSH agent-presets).
+ *
+ * `AGENT_PRESETS` is the FALLBACK roster — the four shipped presets — used
+ * when the live DSH agentPresets service is unreachable. When the service is
+ * up, the bridge renders the dynamic roster (shipped + user-authored) instead;
+ * see the DshSessionBackend.listPresets surface.
+ */
+export const AGENT_PRESETS: ReadonlyArray<AgentPresetOption> = [
 	{
 		id: "standard",
 		label: "标准模式",
 		desc: "全能：文件/Shell/检索/Skills/目标/子代理/工作流",
+		trust: "system",
 	},
 	{
 		id: "code",
 		label: "PTC 模式",
 		desc: "标准能力 + Code Mode（多步操作一次执行，更快）",
+		trust: "system",
 	},
 	{
 		id: "minimal",
 		label: "极简模式",
 		desc: "仅 bash + 文件编辑，轻量省 token",
+		trust: "system",
 	},
 	{
 		id: "cordis",
 		label: "创造模式",
 		desc: "标准能力 + preset 创作工具（面向开发者）",
+		trust: "system",
 	},
 ];
 
@@ -166,13 +175,20 @@ export function questionCard(q: {
 }
 
 /** Single-select mode picker card — tap a button to switch (no typing). */
-export function modeCard(current?: string): unknown {
+export function modeCard(
+	current?: string,
+	presets?: ReadonlyArray<AgentPresetOption>,
+): unknown {
+	const roster = presets && presets.length > 0 ? presets : AGENT_PRESETS;
 	return markdownCard(
 		[
 			"**Agent 模式**（单选，点按钮即切换，下条消息生效）",
 			"",
-			...AGENT_PRESETS.map(
-				(p) => `- ${p.label}${current === p.id ? " ← 当前" : ""}：${p.desc}`,
+			...roster.map(
+				(p) =>
+					`- ${p.label}${p.trust === "user" ? "（自定义）" : ""}${
+						current === p.id ? " ← 当前" : ""
+					}：${p.desc ?? p.id}${p.broken ? `（不可用：${p.broken}）` : ""}`,
 			),
 		].join("\n"),
 		{ header: "切换模式", accent: true },

--- a/src/sessions/dsh-adapter.ts
+++ b/src/sessions/dsh-adapter.ts
@@ -541,6 +541,47 @@ export function createDshAdapter(deps: DshAdapterDeps): DshSessionBackend {
 		},
 		get: (key) => tracked.get(key)?.handle,
 		keyForSessionId: (sessionId) => keyBySession.get(sessionId),
+		async listPresets() {
+			// The roster the deployment currently supplies: shipped presets AND
+			// user-authored (custom) ones. Read live so a preset created while the
+			// bridge runs shows up on the next /mode picker. Falls back to the
+			// shipped four when the agentPresets service is absent or fails.
+			const presets = (
+				c as unknown as {
+					get?(name: string):
+						| {
+								list?(): Promise<
+									Array<{
+										id: string;
+										trust?: "system" | "user";
+										name?: string;
+										description?: string;
+										broken?: string;
+									}>
+								>;
+						  }
+						| undefined;
+				}
+			).get?.("agentPresets");
+			if (!presets?.list) return [];
+			try {
+				const rows = await presets.list();
+				return rows.map((row) => ({
+					id: row.id,
+					label: row.name ?? row.id,
+					...(row.trust === undefined ? {} : { trust: row.trust }),
+					...(row.description === undefined
+						? {}
+						: { desc: row.description }),
+					...(row.broken === undefined ? {} : { broken: row.broken }),
+				}));
+			} catch (err) {
+				deps.logger?.warn(
+					`agentPresets.list() failed — /mode falls back to shipped presets: ${String(err)}`,
+				);
+				return [];
+			}
+		},
 		disposeIdle(idleTtlMs) {
 			let n = 0;
 			for (const t of tracked.values()) {

--- a/src/sessions/dsh-session-backend.ts
+++ b/src/sessions/dsh-session-backend.ts
@@ -7,7 +7,7 @@
 // (used by unit tests and by the bridge when DSH services are absent), plus
 // the real adapter implemented against the DSH Cordis ctx in `dsh-adapter.ts`.
 
-import type { FeishuInboundMessage } from "../common/types.ts";
+import type { FeishuInboundMessage, AgentPresetOption } from "../common/types.ts";
 
 export interface AttachmentInput {
   /** Local file path (image/file). */
@@ -57,6 +57,12 @@ export interface DshSessionBackend {
   get(key: string): AgentHandle | undefined;
   /** Map sessionId back to conversation key (for event routing). */
   keyForSessionId(sessionId: string): string | undefined;
+  /**
+   * The agent presets this deployment currently supplies — shipped AND
+   * user-authored (custom) rows. When DSH's agentPresets service is
+   * unavailable, the memory backend returns the shipped roster only.
+   */
+  listPresets(): Promise<AgentPresetOption[]>;
   /** Dispose idle agents beyond ttl; returns disposed count. */
   disposeIdle(idleTtlMs: number): number;
   /** Bump a conversation's session generation — next ensureAgent uses a fresh id (/new). */
@@ -72,6 +78,16 @@ export interface DshSessionBackend {
 // ---------------------------------------------------------------------------
 // In-memory mock — deterministic, no DSH dependency (unit tests use this).
 // ---------------------------------------------------------------------------
+
+/** The shipped preset roster, mirrored here so the memory backend (used when
+ * DSH services are absent) still answers a /mode picker with the four
+ * official modes. Kept in sync with `AGENT_PRESETS` in presentation/cards. */
+const SHIPPED_PRESETS: AgentPresetOption[] = [
+  { id: "standard", label: "标准模式", desc: "全能：文件/Shell/检索/Skills/目标/子代理/工作流", trust: "system" },
+  { id: "code", label: "PTC 模式", desc: "标准能力 + Code Mode（多步操作一次执行，更快）", trust: "system" },
+  { id: "minimal", label: "极简模式", desc: "仅 bash + 文件编辑，轻量省 token", trust: "system" },
+  { id: "cordis", label: "创造模式", desc: "标准能力 + preset 创作工具（面向开发者）", trust: "system" },
+];
 
 export function createMemoryDshBackend(
   opts: {
@@ -147,6 +163,7 @@ export function createMemoryDshBackend(
     },
     get: (key) => agents.get(key),
     keyForSessionId: (sessionId) => keyBySession.get(sessionId),
+    listPresets: async () => [...SHIPPED_PRESETS],
     disposeIdle(ttlMs) {
       let n = 0;
       for (const [key, a] of agents) {

--- a/test/unit/presentation/cards.test.ts
+++ b/test/unit/presentation/cards.test.ts
@@ -12,6 +12,7 @@ import {
 	setupCard,
 	errorCard,
 	button,
+	modeCard,
 } from "../../../src/presentation/cards.ts";
 
 type Json = Record<string, unknown>;
@@ -116,4 +117,28 @@ test("button helper: primary/danger 样式", () => {
 	assert.equal(danger.type, "danger");
 	const plain = button("状态", { op: "status" }) as Json;
 	assert.equal(plain.type, undefined);
+});
+
+test("modeCard 无名单时回退到官方 4 个模式", () => {
+	const card = modeCard() as Json;
+	const body = card.body as Json;
+	const md = body.elements as Array<{ tag: string; content: string }>;
+	const text = md.find((e) => e.tag === "markdown")!.content;
+	for (const label of ["标准模式", "PTC 模式", "极简模式", "创造模式"]) {
+		assert.ok(text.includes(label), `官方模式 ${label} 应出现在回退卡片`);
+	}
+});
+
+test("modeCard 渲染动态名单（含自定义与不可用标注）", () => {
+	const card = modeCard("aaa", [
+		{ id: "standard", label: "标准模式", trust: "system" },
+		{ id: "aaa", label: "AAA 模式", trust: "user", desc: "示例描述" },
+		{ id: "bbb", label: "BBB 模式", trust: "user", broken: "示例原因" },
+	]) as Json;
+	const body = card.body as Json;
+	const md = body.elements as Array<{ tag: string; content: string }>;
+	const text = md.find((e) => e.tag === "markdown")!.content;
+	assert.ok(text.includes("AAA 模式（自定义） ← 当前"), "自定义模式应标注并高亮当前");
+	assert.ok(text.includes("（不可用：示例原因）"), "broken 模式应标注不可用原因");
+	assert.ok(!text.includes("standard（自定义）"), "官方模式不应标自定义");
 });

--- a/test/unit/sessions/dsh-adapter.test.ts
+++ b/test/unit/sessions/dsh-adapter.test.ts
@@ -79,12 +79,15 @@ function fakeRegistry(
 const ctxOf = (
 	registry: ReturnType<typeof fakeRegistry>,
 	agentDefaultModel?: unknown,
+	agentPresets?: unknown,
 ) =>
 	({
 		agents: registry,
 		// Cordis proxy surface — services are read via ctx.get(), not props.
 		get(name: string) {
-			return name === "agentDefaultModel" ? agentDefaultModel : undefined;
+			if (name === "agentDefaultModel") return agentDefaultModel;
+			if (name === "agentPresets") return agentPresets;
+			return undefined;
 		},
 	}) as unknown as Parameters<typeof createDshAdapter>[0]["ctx"];
 
@@ -287,4 +290,43 @@ test("adapter: /new (rotate) mints a wholly fresh session id (new nonce)", async
 		second.sessionId.endsWith(":0"),
 		"fresh session starts at generation 0",
 	);
+});
+
+test("adapter: listPresets maps the live DSH roster (shipped + custom)", async () => {
+	const registry = fakeRegistry();
+	const agentPresets = {
+		async list() {
+			return [
+				{ id: "standard", trust: "system", name: "标准模式", description: "全能" },
+				{ id: "code", trust: "system" },
+				{ id: "aaa", trust: "user", name: "AAA 模式", description: "示例描述" },
+				{ id: "bbb", trust: "user", broken: "示例原因" },
+			];
+		},
+	};
+	const backend = mkBackend(ctxOf(registry, undefined, agentPresets));
+
+	const presets = await backend.listPresets();
+	assert.deepEqual(presets, [
+		{ id: "standard", trust: "system", label: "标准模式", desc: "全能" },
+		{ id: "code", trust: "system", label: "code" },
+		{ id: "aaa", trust: "user", label: "AAA 模式", desc: "示例描述" },
+		{ id: "bbb", trust: "user", label: "bbb", broken: "示例原因" },
+	]);
+});
+
+test("adapter: listPresets falls back to empty when agentPresets service is absent or fails", async () => {
+	const registry = fakeRegistry();
+	// No agentPresets service at all.
+	const bare = mkBackend(ctxOf(registry, undefined, undefined));
+	assert.deepEqual(await bare.listPresets(), []);
+
+	// Service present but list() rejects.
+	const failing = {
+		async list() {
+			throw new Error("roster unavailable");
+		},
+	};
+	const withFailure = mkBackend(ctxOf(registry, undefined, failing));
+	assert.deepEqual(await withFailure.listPresets(), []);
 });


### PR DESCRIPTION
/mode 从 DSH agentPresets 服务实时读取名册（系统内置 + 用户自建的自定义 preset），选择卡片/按钮动态渲染；自定义项标注「（自定义）」，不可用项标注原因且不出按钮

/mode <id> 支持任意 preset id（含自定义）；服务不可达时回退到内置 4 个官方模式

新增 AgentPresetOption 类型、DshSessionBackend.listPresets() 及内存/DSH 双实现；新增 4 个测试

实际效果
<img width="943" height="902" alt="image" src="https://github.com/user-attachments/assets/eb6eeac6-4c67-4e79-80f5-1600d9cf1a9a" />

## 背景
目前 `/mode` 的模式名册写死在代码里，只有 4 个官方模式。用户在 DSH GUI 里自建的自定义 preset 无法在飞书里看到或切换。

## 改动
- `/mode` 改为从 DSH `agentPresets` 服务实时读取名册（系统内置 + 用户自建自定义 preset），选择卡片/按钮动态渲染
- 自定义项标注「（自定义）」；不可用项标注「（不可用：原因）」且不出按钮
- `/mode <id>` 支持任意 preset id（含自定义）；服务不可达时回退到内置 4 个官方模式
- 新增 `AgentPresetOption` 类型、`DshSessionBackend.listPresets()` 接口及内存/DSH 双实现

## 效果对比

**改动前**（写死 4 个官方模式）：
- 标准模式 / PTC 模式 / 极简模式 / 创造模式

**改动后**（实时名册，示例名册含 1 个自定义 + 1 个不可用项）：
- 标准模式：全能：…
- PTC 模式：…
- 极简模式：…
- 创造模式：…
- AAA 模式（自定义） ← 当前：示例描述
- BBB 模式（自定义）：占位（不可用：示例原因）

按钮列表：标准模式 | PTC 模式 | 极简模式 | 创造模式 | AAA 模式（不可用项自动不生成按钮）

切换回执：
> 模式已切换为 AAA 模式（自定义）（当前会话已重置，下条消息生效；其他会话不受影响）

## 测试
- 新增 4 个测试：`modeCard` 动态名册渲染（含自定义/不可用标注）、`listPresets` 实时映射与失败回退
- `npm test` 132/132 通过；`tsc --noEmit` 通过
