### PR TITLE
fix(client): 弹层改成 body portal，避免与 dsh-cost-meter 抢 sidebar footer 槽位导致的面板变形

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -13,8 +13,10 @@
 //
 // Slot registration: `sidebar.footer.action` is a `list` slot (declared by
 // ui-sidebar); `register` takes the parent name + an entry `id`. The component
-// owns its open/close state; the popover is position:fixed (escapes sidebar
-// overflow).
+// owns its open/close state; the popover is position:fixed and is rendered
+// through a React portal to document.body — it escapes the sidebar footer slot
+// container, so peer footer-slot plugins (e.g. dsh-cost-meter, which rewrites
+// that container's children/order) can never reshape or dislocate it.
 
 import type { Context } from "@deepseek-ai/cordis";
 
@@ -29,6 +31,31 @@ type ReactApi = {
 };
 const R = require("react") as ReactApi;
 const { createElement: h, useState, useEffect } = R;
+// render the popover through a portal to document.body so it escapes the
+// shared sidebar footer slot container. The sidebar.footer.action slot is a
+// LIST where other plugins (e.g. dsh-cost-meter) legitimately reorder the
+// container's children / rewrite its inline flex styles while watching it with
+// a MutationObserver — a popover left as a slot child gets reshuffled by that
+// churn and visibly deforms (GH issue #3). A body portal keeps it stable.
+const reactDom = require("react-dom") as {
+	createPortal?: (node: unknown, container: unknown) => unknown;
+};
+
+const win = globalThis as unknown as {
+	location?: { origin?: string };
+	fetch?: (url: string) => Promise<{ ok: boolean; json(): Promise<unknown> }>;
+	// Browser-only, used as the portal mount target. Kept out of the TS dom lib
+	// (this package's lib is ES2023); accessed lazily through globalThis.
+	document?: { body?: unknown } | null;
+};
+
+// If react-dom.createPortal is available (and we're in a browser), mount via a
+// body portal; otherwise fall back to rendering in place (older runtimes).
+const bodyEl = win.document?.body;
+const portalToBody =
+	bodyEl != null && reactDom.createPortal
+		? (node: unknown) => reactDom.createPortal!(node, bodyEl)
+		: (node: unknown) => node;
 
 export const name = "dsh-lark-link-client";
 export const inject = ["slots"];
@@ -42,11 +69,6 @@ export interface ClientContext extends Context {
 		): () => void;
 	};
 }
-
-const win = globalThis as unknown as {
-	location?: { origin?: string };
-	fetch?: (url: string) => Promise<{ ok: boolean; json(): Promise<unknown> }>;
-};
 
 interface StatusPayload {
 	connState?: string;
@@ -348,7 +370,11 @@ export function apply(ctx: ClientContext): void {
 			footer,
 		);
 
-		return h("div", null, button, panel);
+		// The popover goes through portalToBody (document.body) so another
+		// footer-slot plugin (dsh-cost-meter) reordering the shared sidebar
+		// footer container can never dislocate or deform it. Only the trigger
+		// button stays inside the sidebar footer slot.
+		return h("div", null, button, portalToBody(panel));
 	};
 
 	ctx.slots.inject("sidebar.footer.action", () =>


### PR DESCRIPTION
## 解决的问题 — Closes #3

左下角 dsh-lark-link 图标/弹层和 dsh-cost-meter 插件同占 sidebar.footer.action 槽位打架，展开右上角状态面板前后形态不一致（面板被「变形」）。

## 根因

sidebar.footer.action 是 list 槽位。dsh-cost-meter 的 SidebarFooter 组件会对这个共享容器做实时 DOM 手术（parent.insertBefore / appendChild 改子级顺序 + 改写内联 flex 样式），并用 MutationObserver 监听它。

此前 lark-link 的弹层（position:fixed 状态面板）是作为该容器内的兄弟节点渲染的，任何 childList 变动（面板开关、peer 重渲染）都会触发 cost-meter 的 observer → apply() 强行重排容器子级 → 把 lark-link 的按钮和固定面板一起打乱 → 面板可见地变形。

## 修复

- 弹层改用 ReactDOM portal 渲染到 document.body（与 dsh-cost-chip 相同的逃逸方案），完全离开 shared sidebar footer 容器；只有触发按钮留在槽位内。
- 当 react-dom.createPortal 不可用（旧运行时）时回退为原地渲染，不影响功能。

## 验证

- npx tsc --noEmit 通过
- npm test 全绿（155/155）
- npm run build 重新产出 dist/client.js（react/react-dom 按运行时外部依赖保留 require）

## 影响范围

仅 src/client/index.ts（Web 侧 UI）。宿主逻辑/飞书桥接零改动。
